### PR TITLE
Removed Alamofire dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,12 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftSky",
-    
+    platforms: [
+        .macOS(.v10_10),
+        .iOS(.v8),
+        .tvOS(.v9),
+        .watchOS(.v2)
+    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(


### PR DESCRIPTION
Current version of Alamofire (5.0.0-rc3) has following platforms restrictions:
`platforms: [.macOS(.v10_12),
                                  .iOS(.v10),
                                  .tvOS(.v10),
                                  .watchOS(.v3)]`

In case that I would use Alamofire with SPM and SwiftSky with SPM the version dependency is not handled well there. The easiest solution for me was to remove the dependency to Alamofire from SwiftSky class to prevent code/version collision. For that reason I rewrited the URL request from Alamofire to URLSession. **However it will still be needed to be removed from Pod dependencies**. I did not do it because I saw there are some tests written there with Alamofire...

The reason why I did not put the Alamofire dependency to SPM is because SPM currently cannot handle chained dependencies (especially if someone would like to use some package code in framework...then compile it...than import it and use Alamofire in app mixed with Cocoapods...uhm...long story)